### PR TITLE
Issue#7 fix cli dependency on click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 
     extras_require={
         'cli': [
-            'click',
+            'click==7.1.2',
         ],
         'tests': [
             'mypy',


### PR DESCRIPTION
Pin click version to 7.1.2

See https://github.com/svalouch/python-rctclient/issues/17