### PR TITLE
Try to fix time difference issues of timeseries2csv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             'rctclient=rctclient.cli:cli [cli]',
         ],
     },
+    scripts=['tools/timeseries2csv.py'],
 
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/src/rctclient/cli.py
+++ b/src/rctclient/cli.py
@@ -8,6 +8,7 @@ Command line interface implementation.
 # SPDX-License-Identifier: GPL-3.0-only
 
 import logging
+import pytz
 import select
 import socket
 import sys
@@ -28,6 +29,7 @@ from .types import Command, DataType
 from .utils import decode_value, encode_value
 
 log = logging.getLogger('rctclient.cli')
+gmt = pytz.timezone('GMT')
 
 
 @click.group()
@@ -174,7 +176,7 @@ def read_value(ctx, port: int, host: str, id: Optional[str], name: Optional[str]
     is_ev = oinfo.response_data_type == DataType.EVENT_TABLE
     if is_ts or is_ev:
         sock.send(make_frame(command=Command.WRITE, id=oinfo.object_id,
-                             payload=encode_value(DataType.INT32, int(datetime.now().timestamp()))))
+                             payload=encode_value(DataType.INT32, int(datetime.now().replace(tzinfo=gmt).timestamp()))))
     else:
         sock.send(make_frame(command=Command.READ, id=oinfo.object_id))
     try:

--- a/src/rctclient/cli.py
+++ b/src/rctclient/cli.py
@@ -8,11 +8,10 @@ Command line interface implementation.
 # SPDX-License-Identifier: GPL-3.0-only
 
 import logging
-import pytz
 import select
 import socket
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import List, Optional
 
 try:
@@ -29,7 +28,6 @@ from .types import Command, DataType
 from .utils import decode_value, encode_value
 
 log = logging.getLogger('rctclient.cli')
-gmt = pytz.timezone('GMT')
 
 
 @click.group()
@@ -176,7 +174,7 @@ def read_value(ctx, port: int, host: str, id: Optional[str], name: Optional[str]
     is_ev = oinfo.response_data_type == DataType.EVENT_TABLE
     if is_ts or is_ev:
         sock.send(make_frame(command=Command.WRITE, id=oinfo.object_id,
-                             payload=encode_value(DataType.INT32, int(datetime.now().replace(tzinfo=gmt).timestamp()))))
+                             payload=encode_value(DataType.INT32, int(datetime.now(UTC).timestamp()))))
     else:
         sock.send(make_frame(command=Command.READ, id=oinfo.object_id))
     try:

--- a/src/rctclient/utils.py
+++ b/src/rctclient/utils.py
@@ -3,7 +3,6 @@
 # Copyright 2020-2021, Stefan Valouch (svalouch)
 # SPDX-License-Identifier: GPL-3.0-only
 
-import pytz
 import struct
 from datetime import datetime
 from typing import overload, Dict, Tuple, Union
@@ -16,8 +15,6 @@ except ImportError:
     from typing_extensions import Literal
 
 from .types import DataType, EventEntry
-
-timezone = pytz.timezone('Europe/Berlin')
 
 # pylint: disable=invalid-name
 def CRC16(data: Union[bytes, bytearray]) -> int:
@@ -189,12 +186,12 @@ def _decode_timeseries(data: bytes) -> Tuple[datetime, Dict[datetime, int]]:
     '''
     Helper function to decode the timeseries type.
     '''
-    timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0]))
+    timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0])
     tsval: Dict[datetime, int] = dict()
     assert len(data) % 4 == 0, 'Data should be divisible by 4'
     assert int(len(data) / 4 % 2) == 1, 'Data should be an even number of 4-byte pairs plus the starting timestamp'
     for pair in range(0, int(len(data) / 4 - 1), 2):
-        pair_ts = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]))
+        pair_ts = datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0])
         pair_val = struct.unpack('>f', data[4 + pair * 4 + 4:4 + pair * 4 + 4 + 4])[0]
         tsval[pair_ts] = pair_val
     return timestamp, tsval
@@ -204,7 +201,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
     '''
     Helper function to decode the event table type.
     '''
-    timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0]))
+    timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0])
     tabval: Dict[datetime, EventEntry] = dict()
     assert len(data) % 4 == 0
     assert (len(data) - 4) % 20 == 0
@@ -212,7 +209,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         # this is most likely a single byte of information, but this is not sure yet
         # entry_type = bytes([struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]]).decode('ascii')
         entry_type = struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]
-        timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0]))
+        timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0])
         element2 = struct.unpack('>I', data[4 + pair * 4 + 8:4 + pair * 4 + 12])[0]
         element3 = struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0]
         element4 = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
@@ -227,8 +224,8 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         #                                    value_old=value_old, value_new=value_new)
         # the rest is assumed to be range-based events
         # else:
-        #     timestamp_end = timezone.localize(datetime.utcfromtimestamp(
-        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0]))
+        #     timestamp_end = datetime.utcfromtimestamp(
+        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0])
         #     object_id = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
         #     tabval[timestamp] = EventEntry(timestamp=timestamp, object_id=object_id, entry_type=entry_type,
         #                                    timestamp_end=timestamp_end)

--- a/src/rctclient/utils.py
+++ b/src/rctclient/utils.py
@@ -3,6 +3,7 @@
 # Copyright 2020-2021, Stefan Valouch (svalouch)
 # SPDX-License-Identifier: GPL-3.0-only
 
+import pytz
 import struct
 from datetime import datetime
 from typing import overload, Dict, Tuple, Union
@@ -16,6 +17,7 @@ except ImportError:
 
 from .types import DataType, EventEntry
 
+timezone = pytz.timezone('Europe/Berlin')
 
 # pylint: disable=invalid-name
 def CRC16(data: Union[bytes, bytearray]) -> int:
@@ -187,12 +189,12 @@ def _decode_timeseries(data: bytes) -> Tuple[datetime, Dict[datetime, int]]:
     '''
     Helper function to decode the timeseries type.
     '''
-    timestamp = datetime.fromtimestamp(struct.unpack('>I', data[0:4])[0])
+    timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0]))
     tsval: Dict[datetime, int] = dict()
     assert len(data) % 4 == 0, 'Data should be divisible by 4'
     assert int(len(data) / 4 % 2) == 1, 'Data should be an even number of 4-byte pairs plus the starting timestamp'
     for pair in range(0, int(len(data) / 4 - 1), 2):
-        pair_ts = datetime.fromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0])
+        pair_ts = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]))
         pair_val = struct.unpack('>f', data[4 + pair * 4 + 4:4 + pair * 4 + 4 + 4])[0]
         tsval[pair_ts] = pair_val
     return timestamp, tsval
@@ -202,7 +204,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
     '''
     Helper function to decode the event table type.
     '''
-    timestamp = datetime.fromtimestamp(struct.unpack('>I', data[0:4])[0])
+    timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0]))
     tabval: Dict[datetime, EventEntry] = dict()
     assert len(data) % 4 == 0
     assert (len(data) - 4) % 20 == 0
@@ -210,7 +212,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         # this is most likely a single byte of information, but this is not sure yet
         # entry_type = bytes([struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]]).decode('ascii')
         entry_type = struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]
-        timestamp = datetime.fromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0])
+        timestamp = timezone.localize(datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0]))
         element2 = struct.unpack('>I', data[4 + pair * 4 + 8:4 + pair * 4 + 12])[0]
         element3 = struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0]
         element4 = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
@@ -225,8 +227,8 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         #                                    value_old=value_old, value_new=value_new)
         # the rest is assumed to be range-based events
         # else:
-        #     timestamp_end = datetime.fromtimestamp(
-        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0])
+        #     timestamp_end = timezone.localize(datetime.utcfromtimestamp(
+        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0]))
         #     object_id = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
         #     tabval[timestamp] = EventEntry(timestamp=timestamp, object_id=object_id, entry_type=entry_type,
         #                                    timestamp_end=timestamp_end)

--- a/src/rctclient/utils.py
+++ b/src/rctclient/utils.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import struct
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import overload, Dict, Tuple, Union
 
 try:
@@ -186,12 +186,12 @@ def _decode_timeseries(data: bytes) -> Tuple[datetime, Dict[datetime, int]]:
     '''
     Helper function to decode the timeseries type.
     '''
-    timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0])
+    timestamp = datetime.fromtimestamp(struct.unpack('>I', data[0:4])[0], UTC)
     tsval: Dict[datetime, int] = dict()
     assert len(data) % 4 == 0, 'Data should be divisible by 4'
     assert int(len(data) / 4 % 2) == 1, 'Data should be an even number of 4-byte pairs plus the starting timestamp'
     for pair in range(0, int(len(data) / 4 - 1), 2):
-        pair_ts = datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0])
+        pair_ts = datetime.fromtimestamp(struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0], UTC)
         pair_val = struct.unpack('>f', data[4 + pair * 4 + 4:4 + pair * 4 + 4 + 4])[0]
         tsval[pair_ts] = pair_val
     return timestamp, tsval
@@ -201,7 +201,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
     '''
     Helper function to decode the event table type.
     '''
-    timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[0:4])[0])
+    timestamp = datetime.fromtimestamp(struct.unpack('>I', data[0:4])[0], UTC)
     tabval: Dict[datetime, EventEntry] = dict()
     assert len(data) % 4 == 0
     assert (len(data) - 4) % 20 == 0
@@ -209,7 +209,7 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         # this is most likely a single byte of information, but this is not sure yet
         # entry_type = bytes([struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]]).decode('ascii')
         entry_type = struct.unpack('>I', data[4 + pair * 4:4 + pair * 4 + 4])[0]
-        timestamp = datetime.utcfromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0])
+        timestamp = datetime.fromtimestamp(struct.unpack('>I', data[4 + pair * 4 + 4:4 + pair * 4 + 8])[0], UTC)
         element2 = struct.unpack('>I', data[4 + pair * 4 + 8:4 + pair * 4 + 12])[0]
         element3 = struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0]
         element4 = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
@@ -224,8 +224,8 @@ def _decode_event_table(data: bytes) -> Tuple[datetime, Dict[datetime, EventEntr
         #                                    value_old=value_old, value_new=value_new)
         # the rest is assumed to be range-based events
         # else:
-        #     timestamp_end = datetime.utcfromtimestamp(
-        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0])
+        #     timestamp_end = datetime.fromtimestamp(
+        #         struct.unpack('>I', data[4 + pair * 4 + 12:4 + pair * 4 + 16])[0], UTC)
         #     object_id = struct.unpack('>I', data[4 + pair * 4 + 16:4 + pair * 4 + 20])[0]
         #     tabval[timestamp] = EventEntry(timestamp=timestamp, object_id=object_id, entry_type=entry_type,
         #                                    timestamp_end=timestamp_end)

--- a/tools/timeseries2csv.py
+++ b/tools/timeseries2csv.py
@@ -209,6 +209,7 @@ def timeseries2csv(host: str, port: int, output: Optional[str], header_format: b
 
         while highest_ts > ts_start and not iter_end:
             cprint(f'\ttimestamp: {highest_ts}')
+            # rct power device seems to treat local time at GMT when converting from/to timestamps
             sock.send(make_frame(command=Command.WRITE, id=oid.object_id,
                                  payload=encode_value(DataType.INT32, int(highest_ts.replace(tzinfo=gmt).timestamp()))))
 
@@ -255,6 +256,9 @@ def timeseries2csv(host: str, port: int, output: Optional[str], header_format: b
 
             # work with the data
             for t_ts, t_val in table.items():
+
+                # rct power device seems to treat local time at GMT when converting from/to timestamps
+                t_ts = timezone.localize(t_ts)
 
                 # set the "highest" point in time to know what to request next when the day is not complete
                 if t_ts < highest_ts:

--- a/tools/timeseries2csv.py
+++ b/tools/timeseries2csv.py
@@ -21,7 +21,7 @@ import click
 import pytz
 from dateutil.relativedelta import relativedelta
 
-from rctclient.exceptions import FrameCRCMismatch
+from rctclient.exceptions import FrameCRCMismatch, FrameLengthExceeded, InvalidCommand
 from rctclient.frame import ReceiveFrame, make_frame
 from rctclient.registry import REGISTRY as R
 from rctclient.types import Command, DataType
@@ -229,6 +229,12 @@ def timeseries2csv(host: str, port: int, output: Optional[str], header_format: b
                         except FrameCRCMismatch:
                             cprint('\tCRC error')
                             break
+                        except FrameLengthExceeded:
+                            cprint('\tFrame length exceeded')
+                            break
+                        except InvalidCommand:
+                            cprint('\tInvalid command')
+                            break
                         if rframe.complete():
                             break
                     else:
@@ -238,7 +244,7 @@ def timeseries2csv(host: str, port: int, output: Optional[str], header_format: b
                     cprint('\tTimeout, retrying')
                     break
 
-            if not rframe.complete():
+            if not rframe.complete() or not rframe.crc_ok:
                 cprint('\tIncomplete frame, retrying')
                 continue
 

--- a/tools/timeseries2csv.py
+++ b/tools/timeseries2csv.py
@@ -270,7 +270,7 @@ def timeseries2csv(host: str, port: int, output: Optional[str], header_format: b
                         # correct up to one full minute
                         nt_ts = t_ts.replace(second=0)
                         if nt_ts not in datetable:
-                            nt_ts = t_ts.replace(second=0, minute=t_ts.minute + 1)
+                            nt_ts = t_ts.replace(second=0, minute=(t_ts.minute + 1) % 60, hour=t_ts.hour + (t_ts.minute + 1) // 60)
                             if nt_ts not in datetable:
                                 cprint(f'\t{t_ts} does not fit raster, skipped')
                                 continue


### PR DESCRIPTION
As I argued in https://github.com/svalouch/python-rctclient/issues/7, I think RCT power devices handle timezone information incorrectly when converting between readable dates and timestamps. This PR tries to address this problem.